### PR TITLE
fix: bypass detection via model_function_wrapper

### DIFF
--- a/pulid_flux2.py
+++ b/pulid_flux2.py
@@ -457,10 +457,10 @@ class ApplyPuLIDFlux2:
         if debug_mode:
             print(f"[PuLID Debug] {variant} | {n_double}d / {n_single}s | dim={flux_dim}")
 
-        # Patch via wrapper : appliqué juste avant chaque appel au sampler, retiré après.
-        # Contrairement au patching direct sur le module PyTorch partagé, cette approche
-        # garantit que le bypass fonctionne correctement : un node bypassé ne produit pas
-        # work_model, donc aucun wrapper n'est enregistré et aucun patch n'est appliqué.
+        # Patch via wrapper: applied just before each sampler call, removed after.
+        # Unlike direct patching on the shared PyTorch module, this approach
+        # ensures bypass works correctly: a bypassed node produces no work_model,
+        # so no wrapper is registered and no patch is applied.
         original_wrapper = work_model.model_options.get("model_function_wrapper", None)
         captured = {"injector": injector, "id_tokens": id_tokens, "strength": strength, "debug": debug_mode}
 

--- a/pulid_flux2.py
+++ b/pulid_flux2.py
@@ -457,9 +457,29 @@ class ApplyPuLIDFlux2:
         if debug_mode:
             print(f"[PuLID Debug] {variant} | {n_double}d / {n_single}s | dim={flux_dim}")
 
-        # Patch
-        unpatch = patch_flux(work_model, injector, id_tokens, strength, debug=debug_mode)
-        dm._pulid_unpatcher = unpatch
+        # Patch via wrapper : appliqué juste avant chaque appel au sampler, retiré après.
+        # Contrairement au patching direct sur le module PyTorch partagé, cette approche
+        # garantit que le bypass fonctionne correctement : un node bypassé ne produit pas
+        # work_model, donc aucun wrapper n'est enregistré et aucun patch n'est appliqué.
+        original_wrapper = work_model.model_options.get("model_function_wrapper", None)
+        captured = {"injector": injector, "id_tokens": id_tokens, "strength": strength, "debug": debug_mode}
+
+        def pulid_wrapper(model_function, kwargs):
+            unpatch = patch_flux(
+                get_flux_inner(work_model.model),
+                captured["injector"],
+                captured["id_tokens"],
+                captured["strength"],
+                debug=captured["debug"]
+            )
+            try:
+                if original_wrapper is not None:
+                    return original_wrapper(model_function, kwargs)
+                return model_function(kwargs["input"], kwargs["timestep"], **kwargs["c"])
+            finally:
+                unpatch()
+
+        work_model.set_model_unet_function_wrapper(pulid_wrapper)
 
         emoji = "🟢" if strength >= 1.0 else "🟡" if strength > 0 else "⚪"
         print(f"{emoji} PuLID Flux2 | {variant.upper()} | strength={strength:.2f} | face={face_index}")


### PR DESCRIPTION
## Problem

When the `ApplyPuLIDFlux2` node was bypassed in ComfyUI, PuLID continued to apply to generated images anyway.

**Root cause:** `patch_flux()` was called at node-execution time on `dm` — the underlying shared PyTorch model object. Since `dm` is shared across all clones, the patch persisted at the module level regardless of whether the node was active or bypassed. The returned `unpatch` function was stored on `dm._pulid_unpatcher` but never called.

## Fix

Replace direct module patching with a `model_function_wrapper` registered on `work_model` (the cloned model returned by the node).

- A bypassed node produces no `work_model` output → no wrapper is ever registered → no patch is applied. ✅
- The wrapper calls `patch_flux()` just before each sampler forward pass and `unpatch()` immediately after (in a `finally` block).
- Existing wrappers (e.g. from other nodes) are chained correctly via `original_wrapper`.

## Performance

No regression. `patch_flux()` only swaps Python `.forward` attributes on 32 block objects — no GPU ops, no weight transfers. ComfyUI's node execution cache is unaffected (the wrapper runs during sampling, not during node execution).

## Testing

Validated with three runs on FLUX.2 Klein 9B (6 steps, strength=1.40):
- Group bypassed, debug off → no PuLID output, no log messages ✅
- Group active, debug on → PuLID applied, log messages printed at every step ✅  
- Group bypassed, debug on → no PuLID output, no log messages ✅

---

*Diagnosed and implemented with AI*