### PR TITLE
Fix: prevent cumulative monkey-patching of block.forward across runs

### DIFF
--- a/pulid_flux2.py
+++ b/pulid_flux2.py
@@ -439,6 +439,21 @@ class ApplyPuLIDFlux2:
 
         work_model = model.clone()
         dm = get_flux_inner(work_model)
+
+        # Undo any previous monkey-patch before applying a new one.
+        # patch_flux overwrites block.forward on layer instances that are
+        # shared across runs (model.clone() does not deep-copy them).
+        # Without this cleanup the PuLID corrections stack exponentially
+        # and after 3-4 generations the residual stream degenerates
+        # (banding, ghost face, eventually background only).
+        # Fixes #17.
+        if hasattr(dm, "_pulid_unpatcher"):
+            try:
+                dm._pulid_unpatcher()
+            except Exception as _e:
+                print(f"[PuLID] unpatch warning: {_e}")
+            delattr(dm, "_pulid_unpatcher")
+                  
         variant, flux_dim, n_double, n_single = detect_flux_variant(dm)
 
         # Projection si dimension différente (Klein → Dev)


### PR DESCRIPTION
## Problem

`patch_flux()` overwrites `block.forward` on shared `dm.transformer_blocks[i]` /
`dm.single_transformer_blocks[i]` instances. `work_model = model.clone()`
(`ModelPatcher.clone`) does **not** deep-copy these PyTorch layers, so
the monkey-patch persists across `KSampler` runs.

Each subsequent run does:

```python
original_double[idx] = block.forward          # captures the ALREADY-patched forward
block.forward = make_double_patch(idx)        # wraps it again
```

Effect: PuLID corrections stack exponentially. By run 3-4 the residual
stream is dominated by accumulated `strength × factor × correction`
additions (factor up to 8.0 on early double blocks), producing visible
banding, then a ghost face, and eventually background-only output.

`patch_flux` already returns an `unpatch()` closure and the result is
assigned to `dm._pulid_unpatcher` (line 462), but it is **never called**
anywhere in the file — dead code.

Reported as #17 (and related to #12).

## Fix

Call the previous `_pulid_unpatcher` (if any) at the start of
`ApplyPuLIDFlux2.apply`, right after we obtain `dm`. First run is
unaffected (`hasattr` returns False); every subsequent run cleanly
restores the original `block.forward` before the new patch is applied.

7 lines, no behavior change for the first generation, no new dependencies,
no new public API.

## Test

Repro on Klein 9B fp8, RTX 3090, ComfyUI 0.19.4, 4 steps, euler/simple,
strength sequence 1.3 → 1.09 → 1.5 → 1.3 → 0.64 (5 consecutive runs):

- **Before fix:** run 1 OK, run 2 slight artifacts, run 3 ghost face, run 4 background only (no subject).
- **After fix:** all 5 runs produce a clean, consistent face. No `[PuLID] unpatch warning:` messages in the console.
